### PR TITLE
fixed like insert query, added testing for forum

### DIFF
--- a/src/main/java/tn/esprit/entities/Likes.java
+++ b/src/main/java/tn/esprit/entities/Likes.java
@@ -9,6 +9,10 @@ public class Likes {
         this.post_id = post_id;
     }
 
+    public Likes() {
+
+    }
+
     public int getPost_id() {
         return post_id;
     }

--- a/src/main/java/tn/esprit/services/LikesService.java
+++ b/src/main/java/tn/esprit/services/LikesService.java
@@ -17,7 +17,7 @@ public class LikesService {
 
     public void addOrRemove(Likes like) throws SQLException {
         String checkLikeQuery = "SELECT COUNT(*) FROM likes WHERE Liker_id = ? AND Post_id = ?";
-        String insertLikeQuery = "INSERT INTO likes (Liker_id, Post_id, created_at) VALUES (?, ?, NOW())";
+        String insertLikeQuery = "INSERT INTO likes (Liker_id, Post_id) VALUES (?, ?)";
         String deleteLikeQuery = "DELETE FROM likes WHERE Liker_id = ? AND Post_id = ?";
 
         try (PreparedStatement checkStmt = con.prepareStatement(checkLikeQuery)) {

--- a/src/main/java/tn/esprit/tests/ForumTests.java
+++ b/src/main/java/tn/esprit/tests/ForumTests.java
@@ -1,0 +1,112 @@
+package tn.esprit.tests;
+
+import tn.esprit.entities.FlaggedContent;
+import tn.esprit.entities.Likes;
+import tn.esprit.entities.Posts;
+import tn.esprit.services.FlaggedContentService;
+import tn.esprit.services.LikesService;
+import tn.esprit.services.PostsService;
+
+import java.sql.SQLException;
+import java.util.List;
+
+public class ForumTests {
+    public static void main(String[] args) {
+        testPostsService();
+
+        testLikesService();
+
+        testFlaggedContentService();
+    }
+
+    private static void testFlaggedContentService() {
+        FlaggedContentService service = new FlaggedContentService();
+
+        try {
+            FlaggedContent flaggedContent = new FlaggedContent();
+            flaggedContent.setPost_id(1);
+            flaggedContent.setFlagger_id(2);
+            service.add(flaggedContent);
+            System.out.println("Flagged content added successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error adding flagged content: " + e.getMessage());
+        }
+
+        try {
+            List<FlaggedContent> flaggedContents = service.ListAll();
+            if (!flaggedContents.isEmpty()) {
+                System.out.println("Flagged content listed successfully.");
+            } else {
+                System.out.println("No flagged content found.");
+            }
+        } catch (SQLException e) {
+            System.out.println("Error listing flagged content: " + e.getMessage());
+        }
+
+        try {
+            service.delete(1);
+            System.out.println("Flagged content deleted successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error deleting flagged content: " + e.getMessage());
+        }
+    }
+
+    private static void testPostsService() {
+        PostsService service = new PostsService();
+
+        try {
+            Posts post = new Posts();
+            post.setOwner_id(1);
+            post.setCreated_at(new java.sql.Date(System.currentTimeMillis()));
+            post.setUpdated_at(new java.sql.Date(System.currentTimeMillis()));
+            post.setText_content("Test post content");
+            service.add(post);
+            System.out.println("Post added successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error adding post: " + e.getMessage());
+        }
+
+        try {
+            List<Posts> posts = service.ListAll();
+            if (!posts.isEmpty()) {
+                System.out.println("Posts listed successfully.");
+            } else {
+                System.out.println("No posts found.");
+            }
+        } catch (SQLException e) {
+            System.out.println("Error listing posts: " + e.getMessage());
+        }
+
+        try {
+            Posts postToUpdate = new Posts();
+            postToUpdate.setPost_id(1);
+            postToUpdate.setText_content("Updated post content");
+            postToUpdate.setUpdated_at(new java.sql.Date(System.currentTimeMillis()));
+            service.update(postToUpdate);
+            System.out.println("Post updated successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error updating post: " + e.getMessage());
+        }
+
+        try {
+            service.delete(5);
+            System.out.println("Post deleted successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error deleting post: " + e.getMessage());
+        }
+    }
+
+    private static void testLikesService() {
+        LikesService service = new LikesService();
+
+        try {
+            Likes like = new Likes();
+            like.setLiker_id(1);
+            like.setPost_id(1);
+            service.addOrRemove(like);
+            System.out.println("Like added/removed successfully.");
+        } catch (SQLException e) {
+            System.out.println("Error adding/removing like: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### TL;DR
Added test suite for forum functionality and simplified likes implementation

### What changed?
- Added a new `ForumTests` class with comprehensive test cases for Posts, Likes, and FlaggedContent
- Added empty constructor to Likes entity
- Simplified likes table schema by removing created_at column

### Why make this change?
To ensure reliability of forum features through automated testing and to simplify the likes implementation by removing unnecessary timestamp tracking. This provides better validation of core functionality and reduces database complexity.