### PR TITLE
actually fixed null last_name error

### DIFF
--- a/src/main/java/tn/esprit/entities/Utilisateur.java
+++ b/src/main/java/tn/esprit/entities/Utilisateur.java
@@ -52,7 +52,7 @@ public class Utilisateur {
 
     public String getLast_name() { return last_name; }
 
-    public void setLast_name(String lastname) { this.last_name = last_name; }
+    public void setLast_name(String lastname) { this.last_name = lastname; }
 
     public String getEmail() { return email; }
 


### PR DESCRIPTION
### TL;DR
Fixed a bug in the `setLast_name` method where the parameter wasn't being properly assigned

### What changed?
Corrected the `setLast_name` method in the Utilisateur class to properly assign the `lastname` parameter to the `last_name` field, instead of incorrectly self-assigning the field

### Why make this change?
The previous implementation had a bug where the `last_name` field wasn't being updated with the new value passed to the setter method, causing the field to retain its original value. This fix ensures proper data assignment and maintains object state consistency.