### PR TITLE
flagged content doesn't throw exception if you flag an existing flagged post

### DIFF
--- a/src/main/java/tn/esprit/services/FlaggedContentService.java
+++ b/src/main/java/tn/esprit/services/FlaggedContentService.java
@@ -19,6 +19,17 @@ public class FlaggedContentService implements IService<FlaggedContent> {
 
     @Override
     public void add(FlaggedContent flaggedContent) throws SQLException {
+        String checkQuery = "SELECT * FROM flagged_content WHERE post_id = ? AND flagger_id = ?";
+        try (PreparedStatement stmt = con.prepareStatement(checkQuery)) {
+            stmt.setInt(1, flaggedContent.getPost_id());
+            stmt.setInt(2, flaggedContent.getFlagger_id());
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return;
+                }
+            }
+        }
+
         String insertQuery = "INSERT INTO flagged_content (post_id, flagger_id, flagged_at) VALUES (?, ?, ?)";
         try (PreparedStatement stmt = con.prepareStatement(insertQuery)) {
             stmt.setInt(1, flaggedContent.getPost_id());


### PR DESCRIPTION
### TL;DR
Added duplicate flag check before inserting new flagged content

### What changed?
Added a validation check to prevent duplicate flags from the same user on the same post. The system now verifies if a flag already exists for the given post_id and flagger_id combination before proceeding with the insertion.

### Why make this change?
To prevent duplicate entries in the flagged_content table and ensure data integrity. This change helps maintain accurate flag counts and prevents potential spam or abuse of the flagging system.