### PR TITLE
don't fetch posts flagged by current user

### DIFF
--- a/src/main/java/tn/esprit/controllers/PostsController.java
+++ b/src/main/java/tn/esprit/controllers/PostsController.java
@@ -213,7 +213,7 @@ public class PostsController {
 
     private void loadMorePosts() {
         try {
-            List<Posts> posts = postsService.fetchPosts(currentPostCount, POSTS_BATCH_SIZE);
+            List<Posts> posts = postsService.fetchPosts(currentPostCount, POSTS_BATCH_SIZE, SessionManager.getInstance().getCurrentUtilisateur().getUser_id());
             for (Posts post : posts) {
                 addPostToContainer(post, false);
             }

--- a/src/main/java/tn/esprit/services/PostsService.java
+++ b/src/main/java/tn/esprit/services/PostsService.java
@@ -86,14 +86,19 @@ public class PostsService implements IService<Posts> {
         return posts;
     }
 
-    public List<Posts> fetchPosts(int offset, int limit) throws SQLException {
+    public List<Posts> fetchPosts(int offset, int limit, int userId) throws SQLException {
         List<Posts> posts = new ArrayList<>();
         String query = "SELECT p.*, u.name, u.last_name FROM posts p " +
                 "JOIN users u ON p.Owner_id = u.user_id " +
+                "LEFT JOIN flagged_content f ON p.Post_id = f.post_id AND f.flagger_id = ? " +
+                "WHERE f.post_id IS NULL " +
                 "ORDER BY p.created_at DESC LIMIT ? OFFSET ?";
+
         try (PreparedStatement prepStat = con.prepareStatement(query)) {
-            prepStat.setInt(1, limit);
-            prepStat.setInt(2, offset);
+            prepStat.setInt(1, userId);
+            prepStat.setInt(2, limit);
+            prepStat.setInt(3, offset);
+
             try (ResultSet rs = prepStat.executeQuery()) {
                 while (rs.next()) {
                     Posts post = new Posts();


### PR DESCRIPTION
### TL;DR
Modified post fetching to exclude flagged content for the current user

### What changed?
Updated the post fetching logic to filter out posts that have been flagged by the current user. The query now includes a LEFT JOIN with the flagged_content table and only returns posts that haven't been flagged by the requesting user.

### Why make this change?
To improve user experience by hiding content that users have explicitly flagged as unwanted, while maintaining visibility of these posts for other users who haven't flagged them.